### PR TITLE
Hotfix/rebuildable block crash

### DIFF
--- a/Rustwall/ModSystems/RingedGenerator/RingedGeneratorSystem.cs
+++ b/Rustwall/ModSystems/RingedGenerator/RingedGeneratorSystem.cs
@@ -1,6 +1,8 @@
 ﻿using Cairo;
 using HarmonyLib;
 using ProtoBuf;
+using Rustwall.RWBehaviorRebuildable;
+using Rustwall.RWBlockEntity.BERebuildable;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -798,9 +800,9 @@ namespace Rustwall.ModSystems.RingedGenerator
                 .RequiresPlayer()
                 .WithDescription("Manage rustwall-specific functions")
                 .BeginSubCommand("info")
-                .BeginSubCommand("number")
+                    .BeginSubCommand("number")
                     .WithArgs()
-                    .HandleWith((args) => 
+                    .HandleWith((args) =>
                     {
                         var callerPos = args.Caller.Pos;
                         var ringNumber = RingNumberFromWorldPos((int)callerPos.X, (int)callerPos.Z);
@@ -832,7 +834,8 @@ namespace Rustwall.ModSystems.RingedGenerator
                         //var ringNumber = RingNumberFromWorldPos((int)callerPos.X, (int)callerPos.Z);
                         int regionSize = sapi.WorldManager.RegionSize;
 
-                        bool allmax = ((Func<bool>)(() => { 
+                        bool allmax = ((Func<bool>)(() =>
+                        {
                             int[] data = sapi.WorldManager.GetMapRegion((int)args.Caller.Pos.X / regionSize, (int)args.Caller.Pos.Z / regionSize).ForestMap.Data.ToArray();
                             IMapRegion mapRegion = sapi.WorldManager.GetMapRegion((int)args.Caller.Pos.X / regionSize, (int)args.Caller.Pos.Z / regionSize);
                             foreach (int item in data)
@@ -848,7 +851,7 @@ namespace Rustwall.ModSystems.RingedGenerator
                         return TextCommandResult.Success("all values in this region's forest map are 255: " + allmax);
                     })
                     .EndSubCommand()
-                .EndSubCommand()
+                    .EndSubCommand()
                 .BeginSubCommand("delete")
 
                     .BeginSubCommand("ring")
@@ -881,6 +884,83 @@ namespace Rustwall.ModSystems.RingedGenerator
                     })
                     .EndSubCommand()
 
+                    .BeginSubCommand("blockentity")
+                    .WithArgs(sapi.ChatCommands.Parsers.WorldPosition("position"))
+                    .HandleWith((args) =>
+                    {
+
+                        Vec3d pos = (Vec3d)(args[0]);
+
+                        var be = sapi.World.BlockAccessor.GetBlockEntity<BlockEntityRebuildable>(new BlockPos((int)pos.X, (int)pos.Y, (int)pos.Z));
+                        sapi.World.BlockAccessor.RemoveBlockEntity(be.Pos);
+                        be.MarkDirty(true);
+
+                        return TextCommandResult.Success("delete sumn");
+                    })
+                    .EndSubCommand()
+
+                .EndSubCommand()
+                .BeginSubCommand("repair")
+                    .BeginSubCommand("blockentities")
+                    .WithArgs(sapi.ChatCommands.Parsers.WorldPosition("frompos"), sapi.ChatCommands.Parsers.WorldPosition("topos"))
+                    .HandleWith((args) =>
+                    {
+                        string output = "";
+
+                        Vec3d fromPosd = (Vec3d)args[0];
+                        Vec3i fromPos = new Vec3i((int)fromPosd.X, (int)fromPosd.Y, (int)fromPosd.Z);
+
+                        Vec3d toPosd = (Vec3d)args[1];
+                        Vec3i toPos = new Vec3i((int)toPosd.X, (int)toPosd.Y, (int)toPosd.Z);
+
+                        if (fromPos.X > toPos.X)
+                        {
+                            (fromPos.X, toPos.X) = (toPos.X, fromPos.X);
+                        }
+                        if (fromPos.Y > toPos.Y)
+                        {
+                            (fromPos.Y, toPos.Y) = (toPos.Y, fromPos.Y);
+                        }
+                        if (fromPos.Z > toPos.Z)
+                        {
+                            (fromPos.Z, toPos.Z) = (toPos.Z, fromPos.Z);
+                        }
+
+
+
+                        for (int x = fromPos.X; x <= toPos.X; x++)
+                        {
+                            for (int y = fromPos.Y; y <= toPos.Y; y++)
+                            {
+                                for (int z = fromPos.Z; z <= toPos.Z; z++)
+                                {
+                                    BlockPos targetpos = new BlockPos(x, y, z);
+                                    var targetblock = sapi.World.BlockAccessor.GetBlock(targetpos);
+
+                                    if (
+                                        targetblock.Code.Domain == "rustwall" && 
+                                        (targetblock.BlockBehaviors.ToList().Find(item => item.GetType() == typeof(BehaviorRebuildable)) as BehaviorRebuildable) is not null &&
+                                        (sapi.World.BlockAccessor.GetBlockEntity<BlockEntityRebuildable>(targetpos) is null)
+                                        )
+                                    {
+                                        output += "Found " + targetblock.Code + " at " + targetpos + "\n";
+
+                                        sapi.World.BlockAccessor.SetBlock(0, targetpos);
+                                        sapi.World.BlockAccessor.SetBlock(targetblock.Id, targetpos);
+
+                                        var maybefixedbe = sapi.World.BlockAccessor.GetBlockEntity<BlockEntityRebuildable>(targetpos);
+
+                                        if (maybefixedbe is not null)
+                                        {
+                                            output += "Successfully repaired BERebuildable at " + targetpos + "\n";
+                                            maybefixedbe.MarkDirty(true);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        return TextCommandResult.Success(output);
+                    })
                 .EndSubCommand();
         }
     }

--- a/Rustwall/ModSystems/RustwallModSystem.cs
+++ b/Rustwall/ModSystems/RustwallModSystem.cs
@@ -15,11 +15,16 @@ namespace Rustwall.ModSystems
         public override void StartServerSide(ICoreServerAPI api)
         {
             sapi = api;
-            LoadConfig();
+            //LoadConfig();
             RustwallStartServerSide();
             //loads ALL harmony patches
             var harmony = new Harmony(Mod.Info.ModID);
             harmony.PatchAll();
+        }
+
+        public override void Start(ICoreAPI api)
+        {
+            LoadConfigShared(api);
         }
 
         protected abstract void RustwallStartServerSide();
@@ -43,5 +48,26 @@ namespace Rustwall.ModSystems
                 sapi.StoreModConfig(config, configName);
             }
         }
+
+        protected void LoadConfigShared(ICoreAPI api)
+        {
+            try
+            {
+                config = api.LoadModConfig<RustwallConfig>(configName);
+            }
+            catch (Exception)
+            {
+                api.Logger.Error("Exception loading Rustwall config at " + configName);
+            }
+
+            if (config == null)
+            {
+                api.Logger.Error("Rustwall config not loaded correctly, initializing default.");
+
+                config = new RustwallConfig();
+                api.StoreModConfig(config, configName);
+            }
+        }
+
     }
 }

--- a/Rustwall/ModSystems/RustwallModSystem.cs
+++ b/Rustwall/ModSystems/RustwallModSystem.cs
@@ -10,22 +10,22 @@ namespace Rustwall.ModSystems
     public abstract class RustwallModSystem : ModSystem
     {
         protected ICoreServerAPI sapi;
-        public static RustwallConfig config;
+        public RustwallConfig config;
         private readonly string configName = "rustwall.json";
         public override void StartServerSide(ICoreServerAPI api)
         {
             sapi = api;
-            //LoadConfig();
+            LoadConfig();
             RustwallStartServerSide();
             //loads ALL harmony patches
             var harmony = new Harmony(Mod.Info.ModID);
             harmony.PatchAll();
         }
 
-        public override void Start(ICoreAPI api)
+        /*public override void Start(ICoreAPI api)
         {
             LoadConfigShared(api);
-        }
+        }*/
 
         protected abstract void RustwallStartServerSide();
 

--- a/Rustwall/RWBlockBehavior/BehaviorRebuildable.cs
+++ b/Rustwall/RWBlockBehavior/BehaviorRebuildable.cs
@@ -18,9 +18,9 @@ namespace Rustwall.RWBehaviorRebuildable
         public List<string> itemPerStage { get; private set; } = new List<string>();
         public List<int> quantityPerStage { get; private set; } = new List<int>();
 
-        private static List<ItemStack> allWrenchItemStacks = [];
+        private static List<ItemStack> allWrenchItemStacks = new List<ItemStack>();
 
-        public static RustwallConfig config;
+        public RustwallConfig config;
 
         public BehaviorRebuildable(Block block) : base(block)
         {
@@ -43,7 +43,7 @@ namespace Rustwall.RWBehaviorRebuildable
 
         public override bool OnBlockInteractStart(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel, ref EnumHandling handling)
         {
-            handling = EnumHandling.Handled;
+            handling = EnumHandling.PreventSubsequent;
             ItemSlot slot = byPlayer.InventoryManager.ActiveHotbarSlot;
             BlockEntityRebuildable be = world.BlockAccessor.GetBlockEntity(blockSel.Position) as BlockEntityRebuildable;
 

--- a/Rustwall/RWBlockBehavior/BehaviorRebuildable.cs
+++ b/Rustwall/RWBlockBehavior/BehaviorRebuildable.cs
@@ -2,6 +2,7 @@
 using Rustwall.ModSystems;
 using Rustwall.RWBlockEntity.BERebuildable;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
@@ -20,7 +21,7 @@ namespace Rustwall.RWBehaviorRebuildable
 
         private static List<ItemStack> allWrenchItemStacks = new List<ItemStack>();
 
-        public RustwallConfig config;
+        //public RustwallConfig config;
 
         public BehaviorRebuildable(Block block) : base(block)
         {
@@ -29,7 +30,6 @@ namespace Rustwall.RWBehaviorRebuildable
         public override void Initialize(JsonObject properties)
         {
             base.Initialize(properties);
-            config = RustwallModSystem.config;
             var stages = properties["stages"].AsArray();
 
             //loop through all of the available stages
@@ -113,7 +113,9 @@ namespace Rustwall.RWBehaviorRebuildable
                             slot.Itemstack.Item.DamageItem(world, byPlayer.Entity, slot, quantityPerStage[be.rebuildStage]);
                         }
 
-                        return be.RepairByOneStage(world, slot, blockSel, byPlayer);
+                        bool result = be.RepairByOneStage(world, slot, blockSel, byPlayer);
+
+                        return result;
                     }
                     //otherwise, subtract just one item
                     else
@@ -132,6 +134,54 @@ namespace Rustwall.RWBehaviorRebuildable
                         serverPlayer?.SendIngameError("rustwall:interact-wrongitem");
                     }
                 }
+            }
+
+
+            /// Debug section
+            if (slot.Itemstack.Collectible.Code == "game:peatbrick" && serverPlayer is not null)
+            {
+                if (be is null)
+                {
+                    Debug.WriteLine("Undefined");
+                }
+                else
+                {
+                    string outputText = "";
+                    if (be.rebuildStage == be.maxStage)
+                    {
+                        outputText = "Operational";
+                    }
+                    else if (be.rebuildStage > 0)
+                    {
+                        if (be.repairLock)
+                        {
+                            outputText = "Operational";
+                        }
+                        else
+                        {
+                            outputText = "Damaged";
+                        }
+                    }
+                    else
+                    {
+                        outputText = "Broken";
+                    }
+
+                    int curStability = be.curStability;
+
+                    //if (world?.Api.Side == EnumAppSide.Client && (world?.Api as ICoreClientAPI)?.Settings.Bool.Get("extendedDebugInfo") == true)
+                    {
+                        string machineType = be.rebuildableBlockType == EnumRebuildableBlockType.Simple ? "Simple" : "Complex";
+                        string graceperiod = be.isGracePeriodActive ? (be.gracePeriodExpirationDate - (world.Api as ICoreServerAPI).World.Calendar.ElapsedDays).ToString("#.##") + " days" : "Inactive";
+
+                        outputText += ("\nType: " + machineType + "\nRebuild Stage: " + be.rebuildStage + "\nMax Rebuild Stage: " + be.maxStage + "\nItems Used This Stage: " + be.itemsUsedThisStage + "\nRepair Lock: " + be.repairLock + "\nGrace Period: " + graceperiod);
+
+                        outputText += ("\nCurrent Global Stability Contribution: " + curStability + "\nMax Global Stability Contribution: " + be.maxStability);
+                    }
+
+                    Debug.WriteLine(outputText);
+                }
+
             }
 
             return true;

--- a/Rustwall/RWBlockEntity/BEComplexRebuildable.cs
+++ b/Rustwall/RWBlockEntity/BEComplexRebuildable.cs
@@ -67,7 +67,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
 
             if (animatible)
             {
-                (world.Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, 1337, "deactivate");
+                (world.Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, (int)EnumRebuildableBlockPacket.DeactivateAnimations);
             }
 
             MarkDirty(true);
@@ -105,7 +105,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             }
             else
             {
-                gracePeriodExpirationDate = world.Calendar.ElapsedDays + BehaviorRebuildable.config.GracePeriodDurationRepairOneStage;
+                gracePeriodExpirationDate = world.Calendar.ElapsedDays + ownBehavior.config.GracePeriodDurationRepairOneStage;
             }
 
             MarkDirty(true);
@@ -122,11 +122,11 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             repairLock = true;
             if (animatible)
             {
-                (world.Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, 1337, "activate");
+                (world.Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, (int)EnumRebuildableBlockPacket.ActivateAnimations);
             }
             MarkDirty(true);
 
-            gracePeriodExpirationDate = world.Calendar.ElapsedDays + BehaviorRebuildable.config.GracePeriodDurationRepairFully;
+            gracePeriodExpirationDate = world.Calendar.ElapsedDays + ownBehavior.config.GracePeriodDurationRepairFully;
         }
     }
 }

--- a/Rustwall/RWBlockEntity/BEComplexRebuildable.cs
+++ b/Rustwall/RWBlockEntity/BEComplexRebuildable.cs
@@ -30,6 +30,31 @@ namespace Rustwall.RWBlockEntity.BERebuildable
     {
         public override EnumRebuildableBlockType rebuildableBlockType { get { return EnumRebuildableBlockType.Complex; } }
 
+        public override void Initialize(ICoreAPI api)
+        {
+            base.Initialize(api);
+            
+            if (Block.Variant["repairstate"] == "repaired")
+            {
+                rebuildStage = maxStage;
+            }
+
+            if (isFullyRepaired)
+            {
+                AddContributor(); 
+                repairLock = true;
+            }
+
+            if (animatible)
+            {
+                InitAnimations(api);
+                if (isFullyRepaired)
+                {
+                    ActivateAnimations();
+                }
+            }
+        }
+
         public override bool DamageOneStage(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel)
         {
             if (rebuildStage < 0) { return false; }
@@ -105,7 +130,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             }
             else
             {
-                gracePeriodExpirationDate = world.Calendar.ElapsedDays + ownBehavior.config.GracePeriodDurationRepairOneStage;
+                gracePeriodExpirationDate = world.Calendar.ElapsedDays + GracePeriodDurationRepairOneStage;
             }
 
             MarkDirty(true);
@@ -125,8 +150,8 @@ namespace Rustwall.RWBlockEntity.BERebuildable
                 (world.Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, (int)EnumRebuildableBlockPacket.ActivateAnimations);
             }
             MarkDirty(true);
-
-            gracePeriodExpirationDate = world.Calendar.ElapsedDays + ownBehavior.config.GracePeriodDurationRepairFully;
+                
+            gracePeriodExpirationDate = world.Calendar.ElapsedDays + GracePeriodDurationRepairFully;
         }
     }
 }

--- a/Rustwall/RWBlockEntity/BERebuildable.cs
+++ b/Rustwall/RWBlockEntity/BERebuildable.cs
@@ -1,7 +1,9 @@
-﻿using Rustwall.ModSystems.GlobalStability;
+﻿using Rustwall.ModSystems;
+using Rustwall.ModSystems.GlobalStability;
 using Rustwall.RWBehaviorRebuildable;
 using Rustwall.RWEntityBehavior;
 using System;
+using System.Diagnostics;
 using System.Linq;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
@@ -65,6 +67,8 @@ namespace Rustwall.RWBlockEntity.BERebuildable
         /// Date in calendar days when the grace period will expire. Easier to calculate with.
         /// </summary>
         public double gracePeriodExpirationDate { get; set; }
+        public double GracePeriodDurationRepairOneStage { get; private set; }
+        public double GracePeriodDurationRepairFully { get; private set; }
         public GlobalStabilitySystem globalStabSys;
         public int curStability { get; private set; } 
         public int maxStability { get; private set; } 
@@ -121,14 +125,15 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             }
 
             //Must be done client-side
-            if (animatible)
+            /// TODO: Correct for complex vs simple machines -- damaged simple machines should still animate!
+            /*if (animatible)
             {
                 InitAnimations(api);
                 if (Block.Variant["repairstate"] == "repaired")
                 {
                     ActivateAnimations();
                 }
-            }
+            }*/
 
             ownBehavior = Block.BlockBehaviors.ToList().Find(x => x.GetType() == typeof(BehaviorRebuildable)) as BehaviorRebuildable;
             maxStability = GetBehavior<BEBehaviorGloballyStable>().properties["value"].AsInt();
@@ -152,15 +157,13 @@ namespace Rustwall.RWBlockEntity.BERebuildable
 
             if (api.Side == EnumAppSide.Server)
             {
-                globalStabSys = (api as ICoreServerAPI).ModLoader.GetModSystem<GlobalStabilitySystem>();
+                globalStabSys = sapi.ModLoader.GetModSystem<GlobalStabilitySystem>();
                 globalStabSys.allStableBlockEntities.Add(Pos);
 
-                if (Block.Variant["repairstate"] == "repaired")
-                {
-                    rebuildStage = maxStage;
-                    if (!canRepairBeforeBroken) { repairLock = true; }
-                    AddContributor();
-                }
+                RustwallModSystem rwmodsys = sapi.ModLoader.GetModSystem<RustwallModSystem>();
+
+                GracePeriodDurationRepairOneStage = rwmodsys.config.GracePeriodDurationRepairOneStage;
+                GracePeriodDurationRepairFully = rwmodsys.config.GracePeriodDurationRepairFully;
             }
         }
 
@@ -179,9 +182,9 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             sapi.Logger.Error("Animatible Rustwall Machine initialized with BlockEntityRebuildable. Move it to its own BlockEntity for animations to work!");
         }
 
-        //Because the GlobalStabilitySystem calls ActivateAnimations and DeactivateAnimations on the server side,
-        //we need to make sure the client does the same because animUtil is not defined server-side.
-        //We use network packets to achieve this as it syncs with all players.
+        /// Because the GlobalStabilitySystem calls ActivateAnimations and DeactivateAnimations on the server side,
+        /// we need to make sure the client does the same because animUtil is not defined server-side.
+        /// We use network packets to achieve this as it syncs with all players.
         public override void OnReceivedServerPacket(int packetid, byte[] data)
         {
             switch (packetid)
@@ -253,6 +256,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             }
 
             tree.SetString("rebuildableItemsHash", rebuildableID);
+            tree.SetDouble("gracePeriodExpirationDate", gracePeriodExpirationDate);
         }
 
         public override void FromTreeAttributes(ITreeAttribute tree, IWorldAccessor worldAccessForResolve)
@@ -263,6 +267,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             itemsUsedThisStage = tree.GetAsInt("itemsUsedThisStage");
             repairLock = tree.GetAsBool("repairLock") || false;
             curRebID = tree.GetString("rebuildableItemsHash");
+            gracePeriodExpirationDate = tree.GetDouble("gracePeriodExpirationDate");
         }
     }
 }

--- a/Rustwall/RWBlockEntity/BERebuildable.cs
+++ b/Rustwall/RWBlockEntity/BERebuildable.cs
@@ -52,6 +52,11 @@ namespace Rustwall.RWBlockEntity.BERebuildable
         /// Easy way to access this BE's own behavior
         /// </summary>
         public BehaviorRebuildable ownBehavior;
+        ///
+        /// 
+        /// 
+        public double gracePeriodAddtlTimeOneStage { get; private set; } = 0;
+
         /// <summary>
         /// Simple bool for whether or not the grace period is currently active.
         /// Uses null checks to avoid crashes from server-side or client-side access.
@@ -119,7 +124,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             if (api.Side == EnumAppSide.Server)
             {
                 sapi = api as ICoreServerAPI;
-            } 
+            }
             else if (api.Side == EnumAppSide.Client)
             {
                 capi = api as ICoreClientAPI;

--- a/Rustwall/RWBlockEntity/BERebuildable.cs
+++ b/Rustwall/RWBlockEntity/BERebuildable.cs
@@ -1,28 +1,14 @@
-﻿using Microsoft.Win32.SafeHandles;
-using Rustwall.ModSystems.GlobalStability;
-using Rustwall.ModSystems.RebuildableBlock;
+﻿using Rustwall.ModSystems.GlobalStability;
 using Rustwall.RWBehaviorRebuildable;
 using Rustwall.RWEntityBehavior;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
-using System.Runtime.ConstrainedExecution;
-using System.Runtime.InteropServices.Marshalling;
-using System.Text;
-using System.Threading.Tasks;
-using Vintagestory;
 using Vintagestory.API.Client;
-
-
-//using Rustwall.RWBlockBehavior;
 using Vintagestory.API.Common;
 using Vintagestory.API.Datastructures;
-using Vintagestory.API.MathTools;
 using Vintagestory.API.Server;
 using Vintagestory.API.Util;
 using Vintagestory.GameContent;
-
 
 namespace Rustwall.RWBlockEntity.BERebuildable
 {
@@ -109,7 +95,11 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             Complex
         }
 
-
+        public enum EnumRebuildableBlockPacket
+        {
+            ActivateAnimations = 1337,
+            DeactivateAnimations = 1338
+        }
         
         public bool animatible { get { return GetBehavior<BEBehaviorAnimatable>() is not null; } }
         BlockEntityAnimationUtil animUtil
@@ -194,26 +184,14 @@ namespace Rustwall.RWBlockEntity.BERebuildable
         //We use network packets to achieve this as it syncs with all players.
         public override void OnReceivedServerPacket(int packetid, byte[] data)
         {
-            if (packetid == 1337)
+            switch (packetid)
             {
-                string strData = "";
-                try
-                {
-                    strData = SerializerUtil.Deserialize<string>(data);
-                }
-                catch (Exception e)
-                { 
-                    
-                }
-                
-                if (strData == "activate")
-                {
+                case (int)EnumRebuildableBlockPacket.ActivateAnimations:
                     ActivateAnimations();
-                }
-                else if (strData == "deactivate")
-                {
+                    break;
+                case (int)EnumRebuildableBlockPacket.DeactivateAnimations:
                     DeactivateAnimations();
-                }
+                    break;
             }
         }
 

--- a/Rustwall/RWBlockEntity/BESimpleRebuildable.cs
+++ b/Rustwall/RWBlockEntity/BESimpleRebuildable.cs
@@ -108,10 +108,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             }
             else
             {
-                if (world.Api.Side == EnumAppSide.Server) 
-                {
-                    gracePeriodExpirationDate = world.Calendar.ElapsedDays + BehaviorRebuildable.config.GracePeriodDurationRepairOneStage;
-                }
+                gracePeriodExpirationDate = world.Calendar.ElapsedDays + BehaviorRebuildable.config.GracePeriodDurationRepairOneStage;
             }
 
             //Simple machines should contribute and be animated even if they aren't fully repaired.

--- a/Rustwall/RWBlockEntity/BESimpleRebuildable.cs
+++ b/Rustwall/RWBlockEntity/BESimpleRebuildable.cs
@@ -68,7 +68,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             {
                 /// We have to use packet broadcasts so that when the ModSystem (running only server-side) calls to damage the block,
                 /// the animation change gets synchronized to the client.
-                (world.Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, 1337, "deactivate");
+                (world.Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, (int)EnumRebuildableBlockPacket.DeactivateAnimations);
             }
 
             MarkDirty(true);
@@ -98,6 +98,8 @@ namespace Rustwall.RWBlockEntity.BERebuildable
         {
             world.PlaySoundAt(new AssetLocation("sounds/effect/latch"), blockSel.Position, -0.25, byPlayer, true, 16);
 
+            //world.Api.Logger.Event("RepairByOneStage executed on" + world.Api.Side);
+
             slot.MarkDirty();
             itemsUsedThisStage = 0;
             rebuildStage++;
@@ -108,7 +110,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             }
             else
             {
-                gracePeriodExpirationDate = world.Calendar.ElapsedDays + BehaviorRebuildable.config.GracePeriodDurationRepairOneStage;
+                gracePeriodExpirationDate = world.Calendar.ElapsedDays + ownBehavior.config.GracePeriodDurationRepairOneStage;
             }
 
             //Simple machines should contribute and be animated even if they aren't fully repaired.
@@ -117,7 +119,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
                 AddContributor();
                 if (animatible)
                 {
-                    (world.Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, 1337, "activate");
+                    (world.Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, (int)EnumRebuildableBlockPacket.ActivateAnimations);
                 }
             }
 
@@ -133,11 +135,11 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             if (animatible)
             {
                 //ActivateAnimations();
-                (world.Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, 1337, "activate");
+                (world.Api as ICoreServerAPI)?.Network.BroadcastBlockEntityPacket(Pos, (int)EnumRebuildableBlockPacket.ActivateAnimations);
             }
             MarkDirty(true);
 
-            gracePeriodExpirationDate = world.Calendar.ElapsedDays + BehaviorRebuildable.config.GracePeriodDurationRepairFully;
+            gracePeriodExpirationDate = world.Calendar.ElapsedDays + ownBehavior.config.GracePeriodDurationRepairFully;
         }
     }
 }

--- a/Rustwall/RWBlockEntity/BESimpleRebuildable.cs
+++ b/Rustwall/RWBlockEntity/BESimpleRebuildable.cs
@@ -30,6 +30,30 @@ namespace Rustwall.RWBlockEntity.BERebuildable
     {
         public override EnumRebuildableBlockType rebuildableBlockType { get { return EnumRebuildableBlockType.Simple; } }
 
+        public override void Initialize(ICoreAPI api)
+        {
+            base.Initialize(api);
+
+            if (Block.Variant["repairstate"] == "repaired")
+            {
+                rebuildStage = maxStage;
+            }
+
+            if (rebuildStage > 0)
+            {
+                AddContributor();
+            }
+
+            if (animatible)
+            {
+                InitAnimations(api);
+                if (rebuildStage > 0)
+                {
+                    ActivateAnimations();
+                }
+            }
+        }
+
         public override bool DamageOneStage(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel)
         {
             if (rebuildStage < 0) { return false; }
@@ -98,7 +122,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
         {
             world.PlaySoundAt(new AssetLocation("sounds/effect/latch"), blockSel.Position, -0.25, byPlayer, true, 16);
 
-            //world.Api.Logger.Event("RepairByOneStage executed on" + world.Api.Side);
+            world.Api.Logger.Event("RepairByOneStage executed on " + world.Api.Side);
 
             slot.MarkDirty();
             itemsUsedThisStage = 0;
@@ -110,7 +134,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             }
             else
             {
-                gracePeriodExpirationDate = world.Calendar.ElapsedDays + ownBehavior.config.GracePeriodDurationRepairOneStage;
+                gracePeriodExpirationDate = world.Calendar.ElapsedDays + GracePeriodDurationRepairOneStage;
             }
 
             //Simple machines should contribute and be animated even if they aren't fully repaired.
@@ -139,7 +163,7 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             }
             MarkDirty(true);
 
-            gracePeriodExpirationDate = world.Calendar.ElapsedDays + ownBehavior.config.GracePeriodDurationRepairFully;
+            gracePeriodExpirationDate = world.Calendar.ElapsedDays + GracePeriodDurationRepairFully;
         }
     }
 }

--- a/Rustwall/RWBlockEntity/BESimpleRebuildable.cs
+++ b/Rustwall/RWBlockEntity/BESimpleRebuildable.cs
@@ -108,7 +108,10 @@ namespace Rustwall.RWBlockEntity.BERebuildable
             }
             else
             {
-                gracePeriodExpirationDate = world.Calendar.ElapsedDays + BehaviorRebuildable.config.GracePeriodDurationRepairOneStage;
+                if (world.Api.Side == EnumAppSide.Server) 
+                {
+                    gracePeriodExpirationDate = world.Calendar.ElapsedDays + BehaviorRebuildable.config.GracePeriodDurationRepairOneStage;
+                }
             }
 
             //Simple machines should contribute and be animated even if they aren't fully repaired.

--- a/Rustwall/RWEntityBehavior/BEBehaviorRebuildable.cs
+++ b/Rustwall/RWEntityBehavior/BEBehaviorRebuildable.cs
@@ -1,0 +1,234 @@
+﻿/*using Rustwall.Configs;
+using Rustwall.ModSystems;
+using Rustwall.RWBlockEntity.BERebuildable;
+using System.Collections.Generic;
+using System.Linq;
+using Vintagestory.API.Client;
+using Vintagestory.API.Common;
+using Vintagestory.API.Datastructures;
+using Vintagestory.API.MathTools;
+using Vintagestory.API.Server;
+
+namespace Rustwall.RWEntityBehavior
+{
+    namespace Rustwall.RWBehaviorRebuildable
+    {
+        public class BEBehaviorRebuildable : BlockEntityBehavior
+        {
+            public int numStages = 0;
+            public List<string> itemPerStage { get; private set; } = new List<string>();
+            public List<int> quantityPerStage { get; private set; } = new List<int>();
+
+            private static List<ItemStack> allWrenchItemStacks = new List<ItemStack>();
+
+            public static RustwallConfig config;
+
+            public BEBehaviorRebuildable(BlockEntity be) : base(be)
+            {
+            }
+
+            public override void Initialize(ICoreAPI api, JsonObject properties)
+            {
+                base.Initialize(api, properties);
+                config = RustwallModSystem.config;
+                var stages = properties["stages"].AsArray();
+
+                //loop through all of the available stages
+                foreach (var item in stages)
+                {
+                    itemPerStage.Add(item["item"].AsString());
+                    quantityPerStage.Add(item["quantity"].AsInt());
+                    numStages++;
+                }
+            }
+
+            public override bool OnBlockInteractStart(IWorldAccessor world, IPlayer byPlayer, BlockSelection blockSel, ref EnumHandling handling)
+            {
+                handling = EnumHandling.Handled;
+                ItemSlot slot = byPlayer.InventoryManager.ActiveHotbarSlot;
+                BlockEntityRebuildable be = world.BlockAccessor.GetBlockEntity(blockSel.Position) as BlockEntityRebuildable;
+
+                IServerPlayer serverPlayer = world.Side == EnumAppSide.Server ? (byPlayer as IServerPlayer) : null;
+
+                //there is no case where the block should do something when a player's hand is empty
+                if (slot.Empty || slot.Itemstack == null || be == null)
+                {
+                    serverPlayer?.SendIngameError("rustwall:interact-emptyhand");
+                    return true;
+                }
+
+                if (be.rebuildStage == be.maxStage)
+                {
+                    serverPlayer?.SendIngameError("rustwall:interact-fullyrepaired");
+                    return true;
+                }
+
+                if (be.repairLock)
+                {
+                    serverPlayer?.SendIngameError("rustwall:interact-repairlock");
+                    return true;
+                }
+
+                //if the block is not able to be partially repaired, this resets the repair lock on the block on the next interaction once it breaks fully
+                if (be.repairLock && be.rebuildStage == 0 && be.itemsUsedThisStage == 0)
+                {
+                    be.repairLock = false;
+                }
+
+                //checks if the block needs to be repaired or is repair locked
+                if (be.rebuildStage < numStages && !be.repairLock)
+                {
+                    AssetLocation assetThisStage = new AssetLocation(itemPerStage[be.rebuildStage]);
+
+                    if (assetThisStage.Path == "wrench-*")
+                    {
+                        if (allWrenchItemStacks.Count <= 0)
+                        {
+                            Item[] wrenches = world.SearchItems(assetThisStage);
+                            foreach (var item in wrenches) { allWrenchItemStacks.Add(new ItemStack(item)); }
+                        }
+                    }
+
+                    if (
+                        (
+                        slot.Itemstack?.Collectible.Code.Path == assetThisStage.Path
+                        )
+                        ||
+                        (
+                            assetThisStage.Path == "wrench-*" &&
+                            allWrenchItemStacks.Any(x => (x.Id == slot.Itemstack.Id)) &&
+                            slot.Itemstack.Item.GetRemainingDurability(slot.Itemstack) >= quantityPerStage[be.rebuildStage]
+                        )
+                        ||
+                        (
+                            slot.Itemstack?.Collectible.Code.Path == "wrench-admin"
+                        )
+                    )
+                    {
+                        //if the item is a wrench, repair by a whole stage and subtract durability
+                        if (slot.Itemstack.Collectible.Code.PathStartsWith("wrench"))
+                        {
+                            // If we aren't using the admin wrench, subtract durability
+                            if (!(slot.Itemstack?.Collectible.Code.Path == "wrench-admin"))
+                            {
+                                slot.Itemstack.Item.DamageItem(world, byPlayer.Entity, slot, quantityPerStage[be.rebuildStage]);
+                            }
+
+                            return be.RepairByOneStage(world, slot, blockSel, byPlayer);
+                        }
+                        //otherwise, subtract just one item
+                        else
+                        {
+                            return be.RepairByOneItem(world, slot, blockSel, byPlayer);
+                        }
+                    }
+                    else
+                    {
+                        if (slot.Itemstack.Collectible.Code.PathStartsWith("wrench") && slot.Itemstack.Item.GetRemainingDurability(slot.Itemstack) < quantityPerStage[be.rebuildStage])
+                        {
+                            serverPlayer?.SendIngameError("rustwall:interact-notenoughdurability");
+                        }
+                        else
+                        {
+                            serverPlayer?.SendIngameError("rustwall:interact-wrongitem");
+                        }
+                    }
+                }
+
+                return true;
+            }
+
+            public override string GetPlacedBlockInfo(IWorldAccessor world, BlockPos pos, IPlayer forPlayer)
+            {
+                BlockEntityRebuildable be = world.BlockAccessor.GetBlockEntity(pos) as BlockEntityRebuildable;
+
+                if (be is null)
+                {
+                    return "Undefined";
+                }
+                else
+                {
+                    string outputText = "";
+                    if (be.rebuildStage == be.maxStage)
+                    {
+                        outputText = "Operational";
+                    }
+                    else if (be.rebuildStage > 0)
+                    {
+                        if (be.repairLock)
+                        {
+                            outputText = "Operational";
+                        }
+                        else
+                        {
+                            outputText = "Damaged";
+                        }
+                    }
+                    else
+                    {
+                        outputText = "Broken";
+                    }
+
+                    int curStability = be.curStability;
+
+                    if (world?.Api.Side == EnumAppSide.Client && (world?.Api as ICoreClientAPI)?.Settings.Bool.Get("extendedDebugInfo") == true)
+                    {
+                        string machineType = be.rebuildableBlockType == EnumRebuildableBlockType.Simple ? "Simple" : "Complex";
+                        string graceperiod = be.isGracePeriodActive ? (be.gracePeriodExpirationDate - (world.Api as ICoreClientAPI).World.Calendar.ElapsedDays).ToString("#.##") + " days" : "Inactive";
+
+                        outputText += ("\nType: " + machineType + "\nRebuild Stage: " + be.rebuildStage + "\nMax Rebuild Stage: " + be.maxStage + "\nItems Used This Stage: " + be.itemsUsedThisStage + "\nRepair Lock: " + be.repairLock + "\nGrace Period: " + graceperiod);
+
+                        outputText += ("\nCurrent Global Stability Contribution: " + curStability + "\nMax Global Stability Contribution: " + be.maxStability);
+                    }
+
+                    return outputText;
+                }
+            }
+
+            public override WorldInteraction[] GetPlacedBlockInteractionHelp(IWorldAccessor world, BlockSelection selection, IPlayer forPlayer, ref EnumHandling handling)
+            {
+                var be = selection.Block.GetBlockEntity<BlockEntityRebuildable>(selection);
+                if (be == null || be.rebuildStage == be.maxStage || be.repairLock == true)
+                {
+                    return base.GetPlacedBlockInteractionHelp(world, selection, forPlayer, ref handling);
+                }
+
+                int index = be.rebuildStage;
+                AssetLocation assetThisStage = new AssetLocation(itemPerStage[index]);
+                int quantityThisStage = assetThisStage.Path.StartsWith("wrench") ? 1 : quantityPerStage[index];
+
+                ItemStack[] itemStackThisStage = [];
+
+                if (assetThisStage.Path == "wrench-*")
+                {
+                    if (allWrenchItemStacks.Count <= 0)
+                    {
+                        Item[] wrenches = world.SearchItems(assetThisStage);
+                        foreach (var item in wrenches) { allWrenchItemStacks.Add(new ItemStack(item)); }
+                    }
+
+                    itemStackThisStage = allWrenchItemStacks.ToArray();
+                }
+                else
+                {
+                    itemStackThisStage = [new ItemStack
+                    (
+                    world.GetItem(assetThisStage) != null ? world.GetItem(assetThisStage) : world.GetBlock(assetThisStage),
+                    quantityThisStage - be.itemsUsedThisStage
+                    )];
+                }
+
+                WorldInteraction[] interaction = [new WorldInteraction
+            {
+                MouseButton = EnumMouseButton.Right,
+                ActionLangCode = "rustwall:blockhelp-rebuildable",
+                Itemstacks = itemStackThisStage
+            }];
+
+                return interaction;
+            }
+        }
+    }
+
+}
+*/

--- a/Rustwall/assets/rustwall/shapes/block/rustwallmachinery/gearbox.json
+++ b/Rustwall/assets/rustwall/shapes/block/rustwallmachinery/gearbox.json
@@ -243,7 +243,7 @@
 			"name": "active",
 			"code": "active",
 			"quantityframes": 30,
-			"onActivityStopped": "Rewind",
+			"onActivityStopped": "EaseOut",
 			"onAnimationEnd": "Repeat",
 			"keyframes": [
 				{

--- a/Rustwall/modinfo.json
+++ b/Rustwall/modinfo.json
@@ -7,7 +7,7 @@
       "Vykax"
     ],
     "description": "Custom mod for the spin-off mode of Mudwall",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "dependencies": {
         "game": "1.22.3"
     }


### PR DESCRIPTION
Repair rebuildable block code to fix crashes due to config loading on the client. 
Fix desync and lack of saving on grace periods. 
Add command (/rustwall repair blockentities) for fixing missing blockentities.